### PR TITLE
Feature/multi raw data

### DIFF
--- a/src/RawData/RawDataController.ts
+++ b/src/RawData/RawDataController.ts
@@ -1,28 +1,34 @@
 import { Router, Request, Response } from "express";
 import databaseConnection, {
-    toDBDate,
-    PlotCollection,
-    FilePointer,
-    Upload
+  toDBDate,
+  PlotCollection,
+  FilePointer,
+  Upload
 } from "../databaseConnection";
 import { v4 as uuidv4 } from "uuid";
 import { readRawDataFile, upload } from "./storageController";
 import {
-    INSERT_UPLOAD,
-    INSERT_FILE,
-    GET_ALL_PLOT_COLLECTIONS,
-    GET_PLOT_COLLECTION
+  INSERT_UPLOAD,
+  INSERT_FILE,
+  GET_ALL_PLOT_COLLECTIONS,
+  GET_PLOT_COLLECTION
 } from "./uploadSql";
 import {
-    RawDataGet,
-    RawDataGetValidator,
-    RawDataList,
-    RawDataListValidator
+  RawDataGet,
+  RawDataGetValidator,
+  RawDataList,
+  RawDataListValidator
 } from "./RawDataInterfaces/RawDataValidators";
 import { TypedRequestBody, TypedRequestQuery } from "src/TypedExpressIO";
 import validateBody from "../ValidateBody";
 import { parameterParse } from "../Request/RequestParse";
 import { RawDataRequestQuery } from "src/Request/Request";
+import {
+  calculateParameters,
+  filterPosteriorsFromDataset,
+  getMultipleRawData,
+  getPosteriorData
+} from "./RawDataServices/RawDataService";
 
 // Until accounts are added, all data with be under this user
 const TEMP_USER = "temp";
@@ -31,114 +37,77 @@ const router = Router();
 
 // Can't use validator as multer uses form data to submit files
 router.post("/", upload.any(), async (req: Request, res: Response) => {
-    if (!req.files || !req.body.name) {
-        res.status(400).send({ message: "Missing file or name parameters" });
-        return;
-    }
+  if (!req.files || !req.body.name) {
+    res.status(400).send({ message: "Missing file or name parameters" });
+    return;
+  }
 
-    const collectionId = uuidv4();
-    const fileIds: string[] | undefined = Array.prototype.map.call(
-        req?.files,
-        (file: Express.Multer.File) => file.filename.split(".")[0]
-    );
-    // As a temporary measure until the DB is updated to the latest schema
-    const uploadId = fileIds[0]; // const uploadId = uuidv4();
+  const collectionId = uuidv4();
+  const fileIds: string[] | undefined = Array.prototype.map.call(
+    req?.files,
+    (file: Express.Multer.File) => file.filename.split(".")[0]
+  );
+  // As a temporary measure until the DB is updated to the latest schema
+  const uploadId = fileIds[0]; // const uploadId = uuidv4();
 
-    // Insert plot collection and upload
-    await databaseConnection.query(INSERT_UPLOAD, [
-        uploadId,
-        TEMP_USER,
-        toDBDate(new Date()),
-        collectionId,
-        req.body.name,
-        null
-    ]);
+  // Insert plot collection and upload
+  await databaseConnection.query(INSERT_UPLOAD, [
+    uploadId,
+    TEMP_USER,
+    toDBDate(new Date()),
+    collectionId,
+    req.body.name,
+    null
+  ]);
 
-    // Insert file pointers simultaneously
-    const fileInserts = fileIds?.map((fileId) =>
-        databaseConnection.query(INSERT_FILE, [fileId, uploadId, collectionId])
-    );
-    await Promise.all(fileInserts);
+  // Insert file pointers simultaneously
+  const fileInserts = fileIds?.map((fileId) =>
+    databaseConnection.query(INSERT_FILE, [fileId, uploadId, collectionId])
+  );
+  await Promise.all(fileInserts);
 
-    res.status(200).send({ id: collectionId });
+  res.status(200).send({ id: collectionId });
 });
 
 router.get(
-    "/",
-    validateBody(RawDataListValidator),
-    async (req: TypedRequestBody<RawDataList>, res: Response) => {
-        const [rawDataList] = await databaseConnection.query(
-            GET_ALL_PLOT_COLLECTIONS
-        );
+  "/",
+  validateBody(RawDataListValidator),
+  async (req: TypedRequestBody<RawDataList>, res: Response) => {
+    const [rawDataList] = await databaseConnection.query(
+      GET_ALL_PLOT_COLLECTIONS
+    );
 
-        res.send(rawDataList);
-    }
+    res.send(rawDataList);
+  }
 );
 
 router.get(
-    "/:id",
-    validateBody(RawDataGetValidator),
-    async (req: TypedRequestBody<RawDataGet>, res: Response) => {
-        const [rows] = await databaseConnection.query<
-            (PlotCollection | FilePointer | Upload)[]
-        >(GET_PLOT_COLLECTION, [req.params.id]);
+  "/:id",
+  validateBody(RawDataGetValidator),
+  async (req: TypedRequestBody<RawDataGet>, res: Response) => {
+    // Extract request data
+    const collection_id = req.params.id;
 
-        const rawDataFiles = rows.map(row => readRawDataFile(row.file_id))
-        const data = await Promise.all(rawDataFiles);
-
-        const calculateParameters = (data): string[] => {
-            // get all parameters that are common between all the datasets
-            return data.reduce((acc: string[], curr) => {
-                // First iteration, include all keys of first dataset
-                if (acc === null) {
-                    return Object.keys(curr.posterior.content)
-                }
-
-                // If acc has a key that is not in dataset, remove it
-                for (const key of acc){
-                    if (!curr.posterior.content[key]) {
-                        const index = acc.indexOf(key);
-                        acc.splice(index, 1);
-                    }
-                }
-                return acc
-            }, null) ?? []
-        }
-
-        res.send({
-            id: req.params.id,
-            name: rows[0].collection_name,
-            data: data,
-            parameters: calculateParameters(data),
-        });
-    }
+    // Return the raw data for each file and the set of usable parameters for the plot collection
+    res.status(200).send({
+      id: collection_id,
+      ...(await getMultipleRawData(collection_id))
+    });
+  }
 );
 
 router.get(
   "/:id/posteriors",
   validateBody(RawDataGetValidator),
   async (req: TypedRequestQuery<RawDataRequestQuery>, res: Response) => {
-    const [rows] = await databaseConnection.query<
-      (PlotCollection | FilePointer | Upload)[]
-    >(GET_PLOT_COLLECTION, [req.params.id]);
-    const row = rows[0];
-    const data = await readRawDataFile(row.upload_id);
-    const posteriors = JSON.parse(data).posterior.content;
+    // Extract request data
+    const collection_id = req.params.id;
     const queryPosteriors = parameterParse(req.query?.parameters);
-    const filteredPosteriors = queryPosteriors
-      ? queryPosteriors.reduce(
-          (obj, key) => ({
-            ...obj,
-            [key]: posteriors[key]
-          }),
-          {}
-        )
-      : posteriors;
 
-    res.send({
-      id: req.params.id,
-      name: row.collection_name,
-      posteriors: filteredPosteriors
+    // Return the filtered posterior data
+    res.status(200).send({
+      id: collection_id,
+      ...(await getPosteriorData(collection_id, queryPosteriors))
     });
   }
 );

--- a/src/RawData/RawDataServices/RawDataRepositories/RetrieveRawData.ts
+++ b/src/RawData/RawDataServices/RawDataRepositories/RetrieveRawData.ts
@@ -1,0 +1,21 @@
+import databaseConnection, {
+  PlotCollection,
+  FilePointer,
+  Upload
+} from "../../../databaseConnection";
+import { GET_PLOT_COLLECTION } from "../../uploadSql";
+
+/**
+ * Gets data about each file/dataset used in a plot collection
+ * @param collection_id The UUID of the plot collection
+ * @returns An array containing data for each file used in the plot collection
+ */
+export const getPlotCollectionDataset = async (
+  collection_id: string
+): Promise<(PlotCollection | FilePointer | Upload)[]> => {
+  const [rows] = await databaseConnection.query<
+    (PlotCollection | FilePointer | Upload)[]
+  >(GET_PLOT_COLLECTION, [collection_id]);
+
+  return rows;
+};

--- a/src/RawData/RawDataServices/RawDataService.ts
+++ b/src/RawData/RawDataServices/RawDataService.ts
@@ -1,0 +1,106 @@
+import databaseConnection, {
+  FilePointer,
+  PlotCollection,
+  Upload
+} from "../../databaseConnection";
+import { readRawDataFile } from "../storageController";
+import { GET_PLOT_COLLECTION } from "../uploadSql";
+import { getPlotCollectionDataset } from "./RawDataRepositories/RetrieveRawData";
+
+/**
+ * Gets all parameters that are common between all the datasets
+ * @param data An array of datasets
+ * @returns An array of parameter names common to each dataset
+ */
+export const calculateParameters = (data: any[]): string[] => {
+  return (
+    data.reduce((acc: string[], curr) => {
+      // First iteration, include all keys of first dataset
+      if (acc === null) {
+        return Object.keys(curr.posterior.content);
+      }
+
+      // If acc has a key that is not in dataset, remove it
+      for (const key of acc) {
+        if (!curr.posterior.content[key]) {
+          const index = acc.indexOf(key);
+          acc.splice(index, 1);
+        }
+      }
+      return acc;
+    }, null) ?? []
+  );
+};
+
+/**
+ * Filters a dataset to only contain the requested posteriors
+ * @param data An unfiltered, single dataset
+ * @param requestedPosteriors An array of parameter names to extract from the posteriors
+ * @returns A set of posterior data for only the requested parameter names
+ */
+export const filterPosteriorsFromDataset = (
+  data: any,
+  requestedPosteriors: string[]
+) => {
+  const posteriors = JSON.parse(data).posterior.content;
+  return requestedPosteriors
+    ? requestedPosteriors.reduce(
+        (obj, key) => ({
+          ...obj,
+          [key]: posteriors[key]
+        }),
+        {}
+      )
+    : posteriors;
+};
+
+/**
+ * Gets the data for a given plot collection filtered by an array of parameters. Only works when the
+ * plot collection in question uses a single file/dataset
+ * @param collection_id The UUID of a plot collection
+ * @param queryPosteriors An array of parameter names
+ * @returns The plot collection's name and posterior data, containing only the requested parameters
+ */
+export const getPosteriorData = async (
+  collection_id: string,
+  queryPosteriors: string[]
+) => {
+  // Get the file (single) used in the plot collection
+  const rows = await getPlotCollectionDataset(collection_id);
+
+  // Choose a row, and read its associated (single) file
+  const row = rows[0];
+  const data = await readRawDataFile(row.upload_id);
+
+  // Filter the data from the file according to the requested posteriors
+  const filteredPosteriors = filterPosteriorsFromDataset(data, queryPosteriors);
+
+  return {
+    name: row.collection_name,
+    posteriors: filteredPosteriors
+  };
+};
+
+/**
+ * Gets the raw data for a plot collection. Also works when a plot collection contains multiple datasets
+ * @param collection_id The UUID of the plot collection
+ * @returns The plot collection's name, an array of parameter names that the plot collection can plot with,
+ * and the data for the plot collection
+ */
+export const getMultipleRawData = async (collection_id: string) => {
+  // Get the files contained in the plot collection
+  const rows = await getPlotCollectionDataset(collection_id);
+
+  // Get the full raw data for each file
+  const rawDataFiles = rows.map((row) => readRawDataFile(row.file_id));
+  const data = await Promise.all(rawDataFiles);
+
+  // Extract common parameters between each file
+  const common_parameters = calculateParameters(data);
+
+  return {
+    name: rows[0].collection_name,
+    data: data,
+    parameters: common_parameters
+  };
+};

--- a/src/RawData/RawDataServices/RawDataService.ts
+++ b/src/RawData/RawDataServices/RawDataService.ts
@@ -1,10 +1,4 @@
-import databaseConnection, {
-  FilePointer,
-  PlotCollection,
-  Upload
-} from "../../databaseConnection";
 import { readRawDataFile } from "../storageController";
-import { GET_PLOT_COLLECTION } from "../uploadSql";
 import { getPlotCollectionDataset } from "./RawDataRepositories/RetrieveRawData";
 
 /**

--- a/src/RawData/uploadSql.ts
+++ b/src/RawData/uploadSql.ts
@@ -1,10 +1,10 @@
 export const INSERT_UPLOAD = `
 INSERT INTO upload VALUES (?, ?, ?);
-INSERT INTO plot_collection VALUES (?, ?);
+INSERT INTO plot_collection VALUES (?, ?, ?);
 `;
 
 export const INSERT_FILE = `
-INSERT INTO file_pointer VALUES (?, ?);
+INSERT INTO file_pointer VALUES (?, ?, ?);
 `;
 
 export const GET_ALL_PLOT_COLLECTIONS = `


### PR DESCRIPTION
Updates the `GET /raw-data/:id` endpoint to work for plot collections that use multiple datasets, and restructures the `GET /raw-data/:id/posteriors` endpoint to make its business logic easier to reuse