### PR TITLE
Remove http headers that can be used for fingerprinting

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -34,6 +34,10 @@ app.use(router);
 // instead
 app.use(badRequestErrorHandler);
 
+// Disable http header that reveals this is express.
+// more info: https://www.troyhunt.com/shhh-dont-let-your-response-headers/
+app.disable('x-powered-by');
+
 const port = process.env.PORT;
 app.listen(port, () => {
   console.log(`Backend is running at http://localhost:${port}`);


### PR DESCRIPTION
Removed http header `X-Powered-By` that express puts on every request to make it a bit harder for attackers to figure out what we're using and finding vulnerabilites.This obviously is a bit of security by obscurity but whatever.

More info: 
- https://owasp.org/www-project-web-security-testing-guide/v42/4-Web_Application_Security_Testing/01-Information_Gathering/08-Fingerprint_Web_Application_Framework
- https://www.troyhunt.com/shhh-dont-let-your-response-headers/

See also: https://github.com/FIT3170-FY-Project-7/RABIT-COMMON/pull/16