### PR TITLE
Fixed a bug causing the validator function to incorrectly throw an error

### DIFF
--- a/src/ValidateBody.ts
+++ b/src/ValidateBody.ts
@@ -48,7 +48,7 @@ const validateBody = (typeValidator: t.TypeC<any>, valueValidator?: ErrorFunctio
             validateType(req.body, typeValidator);
             
             // If we are passed the optional validator function, then use it
-            if (typeof valueValidator !== undefined) {
+            if (typeof valueValidator !== 'undefined') {
                 const err = valueValidator(req.body);
                 
                 if (err instanceof Error) {


### PR DESCRIPTION
The validator function was incorrectly checking the type of its optional parameter valueValidator. When one isn't present, it mistakenly thought that there was one