### PR TITLE
Added fixes to replace bad NaNs with proper JSON and bad null values

### DIFF
--- a/src/RawData/storageController.ts
+++ b/src/RawData/storageController.ts
@@ -96,7 +96,7 @@ const splitRawDataStreamIntoParameters = async (
   new Promise((resolve, reject) => {
     const outstandingFunctions: (() => Promise<void>)[] = [];
     fileStream
-      .pipe(replacestream(/:\s*Infinity/g,':null'))
+      .pipe(replacestream(/:\s*Infinity|:\s*NaN/g,':null'))
       .pipe(JSONStream.parse(["posterior", "content", { emitKey: true }]))
       .on("data", async (data: { key: string; value: any[] }) => {
         if (!isNaN(data.value[0]) || (data.value[0] as any).__complex__) {

--- a/src/RawData/storageController.ts
+++ b/src/RawData/storageController.ts
@@ -99,7 +99,7 @@ const splitRawDataStreamIntoParameters = async (
       .pipe(replacestream(/:\s*Infinity|:\s*NaN/g,':null'))
       .pipe(JSONStream.parse(["posterior", "content", { emitKey: true }]))
       .on("data", async (data: { key: string; value: any[] }) => {
-        if (!isNaN(data.value[0]) || (data.value[0] as any).__complex__) {
+        if (data.value[0] && (!isNaN(data.value[0]) || (data.value[0] as any).__complex__)) {
           if ((selectedBuckets[0] == true && intrinsicParameters.includes(data.key)) ||
           (selectedBuckets[1] == true && extrinsicParameters.includes(data.key)) ||
           ((selectedBuckets[2] == true && (


### PR DESCRIPTION
Similar to the issue previously encountered for bad `Infinity`s, the same issue was found to occur for bad `NaN`s. This is a fix for that issue.

Also includes a fix for when a posterior's values are all `null`, which caused a whitescreen crash when attempting to upload and plot them